### PR TITLE
Fix scaling values and names of Krieg's skills

### DIFF
--- a/psycho.html
+++ b/psycho.html
@@ -24,7 +24,7 @@
 	<div class="tree">
 		<div class="tier" data-level="0" data-invested="0" data-total="0">
 			<div class="skill" data-points="0" data-max="5"><img src="icons/psycho-bloodlust-0.png">
-				<div class="description"><h2>Blood-filled Guns</h2><em data-base="+0.5"></em>% Magazine Size per Bloodlust stack<span class="perLevel"> per level</span>.</div>
+				<div class="description"><h2>Blood-Filled Guns</h2><em data-base="+0.5"></em>% Magazine Size per Bloodlust stack<span class="perLevel"> per level</span>.</div>
 				<div class="points"></div>
 			</div>
 			<div class="skill push1" data-points="0" data-max="5"><img src="icons/psycho-bloodlust-1.png">
@@ -34,7 +34,7 @@
 		</div>
 		<div class="tier" data-level="1" data-invested="0" data-total="0">
 			<div class="skill" data-points="0" data-max="5"><img src="icons/psycho-bloodlust-2.png">
-				<div class="description"><h2>Taste of Blood</h2><em data-base="+0.1"></em>% damage reduction during Buzz Axe Rampage per Bloodlust stack<span class="perLevel"> per level</span>. <em data-base="+10"></em> Bloodlust stacks per kill<span class="perLevel"> per level</span> during Buzz Axe Rampage.</div>
+				<div class="description"><h2>Taste of Blood</h2><em data-base="+0.1"></em>% damage reduction during Buzz Axe Rampage per Bloodlust stack<span class="perLevel"> per level</span>. <em  data-mod="5" data-base="+5"></em> Bloodlust stacks per kill<span class="perLevel"> per level</span> during Buzz Axe Rampage.</div>
 				<div class="points"></div>
 			</div>
 			<div class="skill" data-points="0" data-max="5"><img src="icons/psycho-bloodlust-3.png">
@@ -48,7 +48,7 @@
 		</div>
 		<div class="tier" data-level="2" data-invested="0" data-total="0">
 			<div class="skill" data-points="0" data-max="5"><img src="icons/psycho-bloodlust-5.png">
-				<div class="description"><h2>Bloodbath</h2>Kill Skill. Killing an enemy with a grenade or explosion gives <em data-base="+0.5"></em>% weapon damage per Bloodlust stack<span class="perLevel"> per level</span> for a short time. Enemies killed this way have a <em data-base="15"></em>% chance<span class="perLevel"> per level</span> of dropping Grenade ammunition.</div>
+				<div class="description"><h2>Blood Bath</h2>Kill Skill. Killing an enemy with a grenade or explosion gives <em data-base="+0.5"></em>% weapon damage per Bloodlust stack<span class="perLevel"> per level</span> for a short time. Enemies killed this way have a <em data-base="15"></em>% chance<span class="perLevel"> per level</span> of dropping Grenade ammunition.</div>
 				<div class="points"></div>
 			</div>
 			<div class="skill" data-points="0" data-max="1"><img src="icons/psycho-bloodlust-6.png">
@@ -56,7 +56,7 @@
 				<div class="points"></div>
 			</div>
 			<div class="skill" data-points="0" data-max="5"><img src="icons/psycho-bloodlust-7.png">
-				<div class="description"><h2>Fuel the Blood</h2>Kill Skill. Killing an enemy with a melee attack gives <em data-base="+0.5"></em>% Grenade Damage per Bloodlust stack<span class="perLevel"> per level</span> for a short time and adds <em data-base="+2"></em> Bloodlust stacks<span class="perLevel"> per level</span>.</div>
+				<div class="description"><h2>Fuel the Blood</h2>Kill Skill. Killing an enemy with a melee attack gives <em data-base="+0.2"></em>% Grenade Damage per Bloodlust stack<span class="perLevel"> per level</span> for a short time and adds <em data-base="+2"></em> Bloodlust stacks<span class="perLevel"> per level</span>.</div>
 				<div class="points"></div>
 			</div>
 		</div>
@@ -143,7 +143,7 @@
 		</div>
 		<div class="tier" data-level="4" data-invested="0" data-total="0">
 			<div class="skill push1" data-points="0" data-max="5"><img src="icons/psycho-mania-10.png">
-				<div class="description"><h2>Silence the Voices</h2><em data-base="+50"></em>% Melee Damage<span class="perLevel"> per level</span>. <em data-mod="15" data-base="-3"></em>%<span class="perLevel"> per level</span> chance to attack yourself with melee attacks.</div>
+				<div class="description"><h2>Silence the Voices</h2><em data-base="+50"></em>% Melee Damage<span class="perLevel"> per level</span>. <em data-mod="12" data-base="0"></em>% chance to attack yourself with melee attacks.</div>
 				<div class="points"></div>
 			</div>
 		</div>
@@ -185,7 +185,7 @@
 		</div>
 		<div class="tier" data-level="2" data-invested="0" data-total="0">
 			<div class="skill" data-points="0" data-max="5"><img src="icons/psycho-hellborn-4.png">
-				<div class="description"><h2>Elemental Elation</h2>When Elemental Status Effect Damage is being done to enemies you gain stacks of Elemental Elation up to a maximum of 20. Each stack gives <em data-base="+1.0"></em>% Fire Rate and Magazine Size<span class="perLevel"> per level</span>. Stacks will not decay while you are on fire.</div>
+				<div class="description"><h2>Elemental Elation</h2>When Elemental Status Effect Damage is being done to enemies you gain stacks of Elemental Elation up to a maximum of 20. Each stack gives <em data-base="+.5" data-mod=".5"></em>% Fire Rate and <em data-base="+1.0"></em>% Magazine Size<span class="perLevel"> per level</span>. Stacks will not decay while you are on fire.</div>
 				<div class="points"></div>
 			</div>
 			<div class="skill" data-points="0" data-max="1"><img src="icons/psycho-hellborn-5.png">
@@ -193,13 +193,13 @@
 				<div class="points"></div>
 			</div>
 			<div class="skill" data-points="0" data-max="5"><img src="icons/psycho-hellborn-6.png">
-				<div class="description"><h2>Fire Fiend</h2>Melee Attacks have a 10%<span class="perLevel"> per level</span> chance to Ignite enemies. <em data-base="+10"></em>% Weapon Accuracy and <em data-base="+7"></em>% Reload Speed when on fire.</div>
+				<div class="description"><h2>Fire Fiend</h2>Melee Attacks have a <em data-base="+10"></em>%<span class="perLevel"> per level</span> chance to Ignite enemies. <em data-base="+10"></em>% Weapon Accuracy and <em data-base="+7"></em>% Reload Speed when on fire.</div>
 				<div class="points"></div>
 			</div>
 		</div>
 		<div class="tier" data-level="3" data-invested="0" data-total="0">
 			<div class="skill push1" data-points="0" data-max="5"><img src="icons/psycho-hellborn-7.png">
-				<div class="description"><h2>Flame Flare</h2><em data-base="+20"></em>% Burn Duration on you<span class="perLevel"> per level</span>. 15% chance<span class="perLevel"> per level</span> for your Burn effects to apply another Burn effect.</div>
+				<div class="description"><h2>Flame Flare</h2><em data-base="+20"></em>% Burn Duration on you<span class="perLevel"> per level</span>. <em data-base="+15"></em>% chance<span class="perLevel"> per level</span> for your Burn effects to apply another Burn effect.</div>
 				<div class="points"></div>
 			</div>
 			<div class="skill" data-points="0" data-max="1"><img src="icons/psycho-hellborn-8.png">


### PR DESCRIPTION
I corrected a few incorrect scaling values for Krieg's skills, and pedantically changed a couple of skill names to match their names in-game.