### PR TITLE
Added rudimentary Reborn support

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,9 @@
 	<a class="biglink" href="patch/patch.html">
 		<h2>UCP</h2>
 	</a>
+	<a class="biglink" href="reborn/reborn.html">
+		<h2>Reborn</h2>
+	</a>
 </div>
 <!--#include virtual="./footer.txt"-->
 </div>

--- a/reborn/assassin.html
+++ b/reborn/assassin.html
@@ -1,0 +1,215 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>Borderlands 2 Skill Calculator: Assassin</title>
+	<link href='../main.css' rel='stylesheet' type='text/css'>
+	<link href='https://fonts.googleapis.com/css?family=Homenaje' rel='stylesheet' type='text/css'>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.8.1/jquery.min.js"></script>
+	<script src="skillManagerReborn.js"></script>
+</head>
+
+<body class="zero">
+<div class="header">
+	<div class="links"><a class="reset" href="reborn.html">&lt; go back</a> | <a class="reset" href="../">Home</a> | <a href="assassin.html" class="reset">reset</a> | <a href="#" class="permalink">Permalink to this build</a></div>
+	<h1>Borderlands<em>2</em> skill calculator <div class="stamp">(Reborn)</div></h1>
+	<h2>Zer0</h2>
+	<h3>Level <span class="charLevel">5</span> Assassin</h3>
+</div>
+<img unselectable="on" class="portrait" src="../assassinPortrait.png">
+<div class="treeCollection">
+<div class="treewrapper green">
+	<div class="bglayer gray"></div>
+	<div class="bglayer color"></div>
+	<div class="tree">
+		<div class="tier" data-level="0" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/assassin-sniping-0.png">
+				<div class="description"><h2>HeadSh0t</h2><em data-base="+4"></em>% Critical Hit Damage<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/assassin-sniping-1.png">
+				<div class="description"><h2>0ptics</h2><em data-base="+3"></em>% Zoom, <em data-base="+14"></em>% Aim Steadiness, and <em data-base="+14"></em>% Aim Speed and reduced Aim Disruption<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="1" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/assassin-sniping-2.png">
+				<div class="description"><h2>Killer</h2>Kill Skill. Killing an enemy gives you <em data-base="+10"></em>% Critical Hit Damage and <em data-base="+15"></em>% Reload Speed<span class="perLevel"> per level</span> for a few seconds.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/assassin-sniping-3.png">
+				<div class="description"><h2>Precisi0n</h2><em data-base="+5"></em>% Accuracy<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="2" data-invested="0" data-total="0">
+			<div class="skill push1" data-points="0" data-max="1"><img src="../icons/assassin-sniping-5.png">
+				<div class="description"><h2>B0re</h2>Shots pierce through enemies, gaining <em data-base="+100"></em>% damage per enemy pierced. Enemy crit locations highlighted in Decepti0n.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="3" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/assassin-sniping-4.png">
+				<div class="description"><h2>0ne Sh0t 0ne Kill</h2>The first shot from a fully loaded magazine deals <em data-base="+12"></em>% Damage<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/assassin-sniping-6.png">
+				<div class="description"><h2>Vel0city</h2><em data-base="+20"></em>% Bullet Speed, <em data-base="+3"></em>% Critical Hit Damage, and <em data-base="+2"></em>% Gun Damage<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="4" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/assassin-sniping-7.png">
+				<div class="description"><h2>Kill C0nfirmed</h2>Up to <em data-base="+8"></em>% Critical Hit Damage<span class="perLevel"> per level</span> depending on how long you aim down the sights.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/assassin-sniping-8.png">
+				<div class="description"><h2>At 0ne with the Gun</h2><em data-base="+25"></em>% Hip-Shot accuracy, <em data-base="+10"></em>% Reload Speed, and <em data-base="+1"></em> Magazine Size with Sniper Rifles<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="5" data-invested="0" data-total="0">
+			<div class="skill push1" data-points="0" data-max="1"><img src="../icons/assassin-sniping-9.png">
+				<div class="description"><h2>Critical Ascensi0n</h2>Scoring a Critical Hit with a Sniper Rifle gives you <em data-base="+6"></em>% Critical Hit Damage and <em data-base="+5"></em>% Damage with Sniper Rifles. Can stack up to 999 times. Stacks begin to decay if you haven't scored a critical hit in a while. </div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="totalPoints">
+			<span class="totalPoints">0</span>
+		</div>
+		<legend>Sniping</legend>
+	</div>
+</div>
+<div class="treewrapper blue">
+	<div class="bglayer gray"></div>
+	<div class="bglayer color"></div>
+	<div class="tree">
+		<div class="tier" data-level="0" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/assassin-cunning-0.png">
+				<div class="description"><h2>Fast Hands</h2><em data-base="+5"></em>% Reload Speed and <em data-base="+10"></em>% Weapon Swap Speed<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/assassin-cunning-1.png">
+				<div class="description"><h2>C0unter Strike</h2>After getting hit, your next melee attack has a chance to deal <em data-base="+50"></em>% damage<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="1" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/assassin-bloodshed-2.png">
+				<div class="description"><h2>Grim</h2>Kill Skill. Killing an enemy regenerates <em data-base="+0.7"></em>% of your shield per second and gives <em data-base="+2"></em>% Action Skill cooldown rate<span class="perLevel"> per level</span> for a few seconds.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/assassin-cunning-3.png">
+				<div class="description"><h2>Ambush</h2><em data-base="+4"></em>% damage<span class="perLevel"> per level</span> when attacking enemies from behind or when attacking an enemy who is targeting someone other than you.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="2" data-invested="0" data-total="0">
+			<div class="skill push1" data-points="0" data-max="1"><img src="../icons/assassin-cunning-5.png">
+				<div class="description"><h2>Death Mark</h2>Dealing melee damage marks a target for 8 seconds. Marked targets take <em data-base="+80"></em>% additional damage from all sources.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="3" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/assassin-cunning-4.png">
+				<div class="description"><h2>Rising Sh0t</h2>Each successful ranged or melee attack gives you <em data-base="+2"></em>% Gun Damage and <em data-base="+1.8"></em>% Melee Damage<span class="perLevel"> per level</span> for a short time. This bonus can stack up to 5 times. Faster weapons can gain stacks more quickly, but slower weapons retain stacks for a longer period of time.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/assassin-cunning-6.png">
+				<div class="description"><h2>Unf0rseen</h2>Your holographic decoy explodes when you become visible again, causing rank <em data-base="1"></em> shock damage<span class="perLevel"> per level</span> to nearby enemies.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="4" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/assassin-cunning-7.png">
+				<div class="description"><h2>Innervate</h2>While Decepti0n is active you gain <em data-base="+4"></em>% Status Effects Duration Reduction, <em data-base="+7"></em>% Movement Speed, and regenerate <em data-base="+1.0"></em>% of your Maximum Health per second<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/assassin-cunning-8.png">
+				<div class="description"><h2>Tw0 Fang</h2>Every time you fire you have a <em data-base="6"></em>% chance<span class="perLevel"> per level</span> to fire twice.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="5" data-invested="0" data-total="0">
+			<div class="skill push1" data-points="0" data-max="1"><img src="../icons/assassin-cunning-9.png">
+				<div class="description"><h2>Death Bl0ss0m</h2>Action Skill Augment. Throws a handful of Kunai knives. Has a random elemental effect. Does not take character out of Decepti0n. Can be used five times per cooldown. Can apply Death Mark. </div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="totalPoints">
+			<span class="totalPoints">0</span>
+		</div>
+		<legend>Cunning</legend>
+	</div>
+</div>
+<div class="treewrapper red">
+	<div class="bglayer gray"></div>
+	<div class="bglayer color"></div>
+	<div class="tree">
+		<div class="tier" data-level="0" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/assassin-bloodshed-0.png">
+				<div class="description"><h2>Killing Bl0w</h2><em data-base="+100"></em>% Melee Damage<span class="perLevel"> per level</span> against enemies with low health.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/assassin-bloodshed-1.png">
+				<div class="description"><h2>Ir0n Hand</h2><em data-base="+3"></em>% Melee Damage and <em data-base="+5"></em> Health Damage Reduction<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="1" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/assassin-cunning-2.png">
+				<div class="description"><h2>Fearless</h2><em data-base="+5"></em>% Fire Rate and <em data-base="+0.3"></em>% Health Regeneration<span class="perLevel"> per level</span> when your shield is depleted.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/assassin-bloodshed-3.png">
+				<div class="description"><h2>Be Like Water</h2>Shooting an enemy gives <em data-base="+6"></em>% damage<span class="perLevel"> per level</span> to your next melee attack. Melee Attacks give <em data-base="+4"></em>% damage<span class="perLevel"> per level</span> to your next gun attack.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="2" data-invested="0" data-total="0">
+			<div class="skill push1" data-points="0" data-max="1"><img src="../icons/assassin-bloodshed-5.png">
+				<div class="description"><h2>Execute</h2>Melee Override Skill. While Decepti0n is active and a target is under your crosshairs, melee to dash forward a short distance and perform a special melee attack, dealing massive damage. Has a range of 3 meters.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="3" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/assassin-bloodshed-4.png">
+				<div class="description"><h2>F0ll0wthr0ugh</h2>Kill Skill. Killing an enemy gives <em data-base="+8"></em>% Movement Speed, <em data-base="+6"></em>% Gun Damage, and <em data-base="+8"></em>% Melee Damage<span class="perLevel"> per level</span> for a few seconds.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/assassin-bloodshed-6.png">
+				<div class="description"><h2>Backstab</h2>Your melee attacks deal <em data-base="+8"></em>% damage<span class="perLevel"> per level</span> when hitting an enemy in the back, dealing massive damage.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="4" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/assassin-bloodshed-7.png">
+				<div class="description"><h2>Resurgence</h2>Killing an enemy with a melee attack restores up to <em data-base="+6"></em>% of your health<span class="perLevel"> per level</span> depending on how low your health is.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/assassin-bloodshed-8.png">
+				<div class="description shortTier4Description"><h2>Like The Wind</h2><em data-base="+5"></em>% chance to dodge bullets and status effects<span class="perLevel"> per level</span> when moving.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="5" data-invested="0" data-total="0">
+			<div class="skill push1" data-points="0" data-max="1"><img src="../icons/assassin-bloodshed-9.png">
+				<div class="description"><h2>Many Must Fall</h2>Killing an enemy with a Melee Attack during Decepti0n deploys an additional holographic decoy and extends the duration of Decepti0n instead of ending it. </div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="totalPoints">
+			<span class="totalPoints">0</span>
+		</div>
+		<legend>Bloodshed</legend>
+	</div>
+</div>
+</div>
+
+<div class="summary">
+	<div class="descriptionContainer"></div>
+	<div class="footer">Art &copy; 2012 <a href="http://www.gearboxsoftware.com/" target="_blank">Gearbox Studios</a>. <a href="https://www.google.com/webfonts" target="_blank">Fonts</a> by Google. Code hosted on Github. <a href="https://github.com/seigler/bl2skills.com">Source Code</a>.</div>
+	<!--#include virtual="./footer.txt"-->
+</div>
+</body>
+</html>

--- a/reborn/commando.html
+++ b/reborn/commando.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>Borderlands 2 Skill Calculator: Commando</title>
+	<link href='../main.css' rel='stylesheet' type='text/css'>
+	<link href='https://fonts.googleapis.com/css?family=Homenaje' rel='stylesheet' type='text/css'>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.8.1/jquery.min.js"></script>
+	<script src="skillManagerReborn.js"></script>
+</head>
+<body>
+
+<div class="header">
+	<div class="links"><a class="reset" href="reborn.html">&lt; go back</a> | <a class="reset" href="../">Home</a> | <a href="commando.html" class="reset">reset</a> | <a href="#" class="permalink">Permalink to this build</a></div>
+	<h1>Borderlands<em>2</em> skill calculator <div class="stamp">(Reborn)</div></h1>
+	<h2>Axton</h2>
+	<h3>Level <span class="charLevel">5</span> Commando</h3>
+</div>
+<img unselectable="on" class="portrait" src="../commandoPortrait.png">
+<div class="treeCollection">
+<div class="treewrapper green">
+	<div class="bglayer gray"></div>
+	<div class="bglayer color"></div>
+	<div class="tree">
+		<div class="tier" data-level="0" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/commando-guerilla-0.png">
+				<div class="description"><h2>Sentry</h2><em data-base="+1"></em> shots fired per burst<span class="perLevel"> per level</span> and <em data-base="+2"></em> seconds turret duration<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/commando-guerilla-1.png">
+				<div class="description"><h2>Ready</h2><em class="" data-base="+8"></em>% Reload Speed<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="1" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/commando-guerilla-2.png">
+				<div class="description"><h2>Laser Sight</h2><em class="change" data-base="+5"></em>% Turret Accuracy and <em data-base="+5"></em>% Turret Fire Rate<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/commando-guerilla-3.png">
+				<div class="description"><h2>Willing</h2><em data-base="+15"></em>% Shield Recharge Rate and <em data-base="-12"></em>% Shield Recharge Delay<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="2" data-invested="0" data-total="0">
+			<div class="skill push1" data-points="0" data-max="1"><img src="../icons/commando-guerilla-5.png">
+				<div class="description"><h2>Scorched Earth</h2>Adds Multi-Rocket Pods to your Sabre Turret. 22 Rockets per Volley. <span class="change"> Also Increases Axton's Explosive Damage by 10%</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="3" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/commando-guerilla-4.png">
+				<div class="description"><h2>Onslaught</h2>Kill Skill. Killing an enemy gives you <em data-base="+6"></em>% Gun Damage and <em data-base="+12"></em>% Movement Speed<span class="perLevel"> per level</span> for a short time.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/commando-guerilla-6.png">
+				<div class="description"><h2>Able</h2>Damaging an enemy regenerates <em data-base="+0.4"></em>% of your Maximum Health per second<span class="perLevel"> per level</span> for 3 seconds.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="4" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/commando-guerilla-7.png">
+				<div class="description"><h2>Grenadier</h2><em data-base="+1"></em> Grenade Capacity and <em data-base="+3"></em>% Grenade Damage<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/commando-survival-7.png">
+				<div class="description"><h2>Resourceful</h2><em data-base="+5"></em>% Action Skill Cooldown Rate<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="5" data-invested="0" data-total="0">
+			<div class="skill push1" data-points="0" data-max="1"><img src="../icons/commando-guerilla-9.png">
+				<div class="description"><h2>Double Up</h2>Adds a second gun to the Sabre Turret and both guns fire Slag bullets. <span class="change">Also increases Sabre Turret Damage by 30%.</span></div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="totalPoints">
+			<span class="totalPoints">0</span>
+		</div>
+		<legend>Guerilla</legend>
+	</div>
+</div>
+<div class="treewrapper blue">
+	<div class="bglayer gray"></div>
+	<div class="bglayer color"></div>
+	<div class="tree">
+		<div class="tier" data-level="0" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/commando-gunpowder-0.png">
+				<div class="description"><h2>Impact</h2><em data-base="+4"></em>% Gun Damage and <em data-base="+3"></em>%<span class="change"> Accuracy</span><span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/commando-gunpowder-1.png">
+				<div class="description"><h2>Expertise</h2><em data-base="+14"></em>% weapon swap and aim speed<span class="perLevel"> per level</span>; <em data-base="+7"></em>% movement speed when aiming<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="1" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/commando-gunpowder-2.png">
+				<div class="description"><h2>Overload</h2><em data-base="+6"></em>% Magazine Size and <em data-base="+3"></em>% Ammo Capacity.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/commando-gunpowder-3.png">
+				<div class="description"><h2>Metal Storm</h2>Kill Skill. Killing an enemy gives <em data-base="+12"></em>% Fire Rate and <em data-base="+15"></em>% Recoil Reduction<span class="perLevel"> per level</span> for a short time.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier push1" data-level="2" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="1"><img src="../icons/commando-gunpowder-5.png">
+				<div class="description"><h2>Longbow Turret</h2><em data-base="+10000"></em>% Turret Deploy Range, <em data-base="+110"></em>% Turret Health.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="3" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/commando-gunpowder-4.png">
+				<div class="description"><h2>Steady</h2><em data-base="+8"></em>% Recoil Reduction, <em data-base="+5"></em>% Grenade Damage, and <em data-base="+4"></em>% Rocket Launcher damage<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="1"><img src="../icons/commando-gunpowder-8.png">
+				<div class="description"><h2>Do or Die</h2>Allows you to throw grenades while in Fight for Your Life. <em data-base="+10"></em>% Grenade and Rocket Launcher damage.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/commando-gunpowder-6.png">
+				<div class="description"><h2>Battlefront</h2><em data-base="+6"></em>% Gun, Critical Hit Damage, and Grenade damage<span class="perLevel"> per level</span> while turret is deployed.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="4" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/commando-gunpowder-7.png">
+				<div class="description"><h2>Duty Calls</h2><em data-base="+8"></em>% Gun Damage and <em data-base="+3"></em>% Critical Hit Damage with non-elemental guns.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/commando-gunpowder-9.png">
+				<div class="description"><h2>Ranger</h2><em data-base="+2"></em>% Gun Damage, Accuracy, Critical Hit Damage, Fire Rate, Magazine Size, Reload Speed, and Maximum Health<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier push1" data-level="5" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="1"><img src="../icons/commando-gunpowder-10.png">
+				<div class="description"><h2>Nuke</h2>Deploying your Sabre Turret sets off a small Nuclear Blast and passively increase Axton's Cooldown Rate by 20%. </div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="totalPoints">
+			<span class="totalPoints">0</span>
+		</div>
+		<legend>Gunpowder</legend>
+	</div>
+</div>
+<div class="treewrapper red">
+	<div class="bglayer gray"></div>
+	<div class="bglayer color"></div>
+	<div class="tree">
+		<div class="tier" data-level="0" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/commando-survival-0.png">
+				<div class="description"><h2>Healthy</h2><em data-base="+6"></em>% Maximum Health<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/commando-survival-1.png">
+				<div class="description"><h2>Preparation</h2><em data-base="+4"></em>% shield capacity<span class="perLevel"> per level</span>; regenerate <em data-base="+0.4"></em>% health per second<span class="perLevel"> per level</span> when shields are full.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="1" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/commando-survival-2.png">
+				<div class="description"><h2>Last Ditch Effort</h2><em data-base="+8"></em>% Gun Damage and Fight For Your Life time as well as <em data-base="+14"></em>% Movement Speed<span class="perLevel"> per level</span> during Fight For Your Life.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/commando-survival-3.png">
+				<div class="description"><h2>Pressure</h2>Up to <em data-base="+14"></em>% Reload Speed and <em data-base="-14"></em>% Shield Recharge Delay<span class="perLevel"> per level</span> depending on how low your health is.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="2" data-invested="0" data-total="0">
+			<div class="skill push1" data-points="0" data-max="1"><img src="../icons/commando-survival-5.png">
+				<div class="description"><h2>Phalanx Shield</h2>Your Sabre Turret projects a shield that attempts to block enemy ranged fire but lets friendly ranged attacks pass through. Also passively increases Axton's Shield Capacity by 20%</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="3" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/commando-survival-4.png">
+				<div class="description"><h2>Forbearance</h2><em data-base="-8"></em>% Status Effect duration on you and <em data-base="+2"></em>% Damage Reduction<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="1"><img src="../icons/commando-survival-8.png">
+				<div class="description"><h2>Mag-Lock</h2>Your Sabre Turret can be deployed on walls and ceilings.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/commando-survival-6.png">
+				<div class="description"><h2>Quick Charge</h2>Kill Skill. Killing an enemy regenerates <em data-base="+1"></em>% of your shield per second<span class="perLevel"> per level</span> for a short time.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="4" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/commando-guerilla-8.png">
+				<div class="description"><h2>Crisis Management</h2><em data-base="+7"></em>% Gun Damage and <em data-base="+6"></em>% Damage Reduction<span class="perLevel"> per level</span> when shields are depleted.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/commando-survival-9.png">
+				<div class="description"><h2>Grit</h2>You have a <em data-base="4"></em>% chance<span class="perLevel"> per level</span> to ignore damage that would otherwise kill you. In addition to not taking damage from the attack, you will also regain half your maximum health.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier push1" data-level="5" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="1"><img src="../icons/commando-survival-10.png">
+				<div class="description"><h2>Gemini</h2>Allows you to deploy two Sabre Turrets. Additionally gives the turret 30% Fire Rate and 3 more shots per burst.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="totalPoints">
+			<span class="totalPoints">0</span>
+		</div>
+		<legend>Survival</legend>
+	</div>
+</div>
+</div>
+
+<div class="summary">
+	<div class="descriptionContainer"></div>
+	<div class="footer">Art &copy; 2012 <a href="http://www.gearboxsoftware.com/" target="_blank">Gearbox Studios</a>. <a href="https://www.google.com/webfonts" target="_blank">Fonts</a> by Google. Code hosted on Github. <a href="https://github.com/seigler/bl2skills.com">Source Code</a>.</div>
+</div>
+
+</body>
+</html>

--- a/reborn/gunzerker.html
+++ b/reborn/gunzerker.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>Borderlands 2 Skill Calculator: Gunzerker</title>
+	<link href='../main.css' rel='stylesheet' type='text/css'>
+	<link href='https://fonts.googleapis.com/css?family=Homenaje' rel='stylesheet' type='text/css'>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.8.1/jquery.min.js"></script>
+	<script src="skillManagerReborn.js"></script>
+</head>
+<body>
+
+<div class="header">
+	<div class="links"><a class="reset" href="reborn.html">&lt; go back</a> | <a class="reset" href="../">Home</a> | <a href="gunzerker.html" class="reset">reset</a> | <a href="#" class="permalink">Permalink to this build</a></div>
+	<h1>Borderlands<em>2</em> skill calculator <div class="stamp">(Reborn)</div></h1>
+	<h2>Salvador</h2>
+	<h3>Level <span class="charLevel">5</span> Gunzerker</h3>
+</div>
+<img unselectable="on" class="portrait" src="../gunzerkerPortrait.png" style="left: 30%;margin-left: -50%;">
+<div class="treeCollection">
+<div class="treewrapper green">
+	<div class="bglayer gray"></div>
+	<div class="bglayer color"></div>
+	<div class="tree">
+		<div class="tier" data-level="0" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/gunzerker-gunlust-0.png">
+				<div class="description"><h2>Locked And Loaded</h2>Reloading your gun gives you <em data-base="+5"></em>% Fire Rate<span class="perLevel"> per level</span> for a short time.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/gunzerker-gunlust-1.png">
+				<div class="description"><h2>Quick Draw</h2><em data-base="+10"></em>% Weapon Swap Speed and <em data-base="-5"></em>% Weapon Equip Time<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="1" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/gunzerker-gunlust-2.png">
+				<div class="description"><h2>I'm Your Huckleberry</h2><em data-base="+3.5"></em>% Damage and Reload Speed<span class="perLevel"> per level</span> with pistols.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/gunzerker-gunlust-3.png">
+				<div class="description"><h2>All I Need is One</h2>Swapping weapons causes your next shot fired to deal up to <em data-base="+11"></em>% damage<span class="perLevel"> per level</span>. This bonus decreases as your magazine is emptied.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="2" data-invested="0" data-total="0">
+			<div class="skill push1" data-points="0" data-max="1"><img src="../icons/gunzerker-gunlust-5.png">
+				<div class="description"><h2>Auto-Loader</h2>Killing an enemy Instantly Reloads all of the guns that you have equipped that are not currently in your hands. Swapping guns after Auto-Loader has reloaded a gun triggers Locked &amp; Loaded. Additionally passively increases Salvador's Reload Speed by 15% now.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="3" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/gunzerker-gunlust-4.png">
+				<div class="description"><h2>Divergent Likeness</h2><em data-base="+6"></em>% Damage when Gunzerking with two of the same type of guns. <em data-base="+6"></em>% Accuracy when Gunzerking with two different types of guns.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="1"><img src="../icons/gunzerker-gunlust-8.png">
+				<div class="description"><h2>Down Not Out</h2>You can Gunzerk while in Fight for Your Life.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/gunzerker-gunlust-6.png">
+				<div class="description"><h2>Money Shot</h2>The last bullet fired from any gun does <em data-base="+12"></em>% damage<span class="perLevel"> per level</span> per magazine size, up to <em data-base="+96"></em>% damage<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="4" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/gunzerker-gunlust-7.png">
+				<div class="description"><h2>Lay Waste</h2>Kill Skill. Killing an enemy gives <em data-base="+8"></em>% Fire Rate and <em data-base="+5"></em>% Critical Hit Damage and <em data-base="0.2"></em> ammo regeneration with guns<span class="perLevel"> per level</span> for a short time. Rockets receive heavily reduced regeneration.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/gunzerker-gunlust-9.png">
+				<div class="description"><h2>Keep It Piping Hot</h2>While Gunzerking is in the process of cooling down you gain <em data-base="+6"></em>% Gun Damage, Melee Damage, and Grenade Damage<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="5" data-invested="0" data-total="0">
+			<div class="skill push1" data-points="0" data-max="1"><img src="../icons/gunzerker-gunlust-10.png">
+				<div class="description"><h2>No Kill Like Overkill</h2>Any excess damage dealt to an enemy that kills them is transferred to the next enemy fired at.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="totalPoints">
+			<span class="totalPoints">0</span>
+		</div>
+		<legend>Gunlust</legend>
+	</div>
+</div>
+
+<div class="treewrapper blue">
+	<div class="bglayer gray"></div>
+	<div class="bglayer color"></div>
+	<div class="tree">
+		<div class="tier" data-level="0" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/gunzerker-rampage-4.png">
+				<div class="description"><h2>I'm Ready Already</h2><em data-base="+5"></em>% Gunzerking Cooldown Rate.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/gunzerker-rampage-1.png">
+				<div class="description"><h2>Filled to the Brim</h2><em data-base="+5"></em>% Magazine Capacity and <em data-base="+0.1"></em>% Ammo Regeneration<span class="perLevel"> per level</span> for all ammo types. Rockets receive heavily reduced regeneration.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="1" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/gunzerker-rampage-2.png">
+				<div class="description"><h2>All in the Reflexes</h2><em data-base="+5"></em>% Reload Speed and Melee Damage<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/gunzerker-rampage-3.png">
+				<div class="description"><h2>Last Longer</h2><em data-base="+3"></em> seconds Gunzerking duration<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="2" data-invested="0" data-total="0">
+			<div class="skill push1" data-points="0" data-max="1"><img src="../icons/gunzerker-rampage-5.png">
+				<div class="description"><h2>Steady as She Goes</h2><em data-base="+80"></em>% Recoil Reduction and <em data-base="40"></em>% chance to improve Accuracy on hit when Gunzerking.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="3" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/gunzerker-rampage-0.png">
+				<div class="description"><h2>Inconceivable</h2>Up to <em data-base="9"></em>% chance<span class="perLevel"> per level</span> for shots not to consume ammo. The more ammo is currently in your magazine the greater the chance of Free Shots.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="1"><img src="../icons/gunzerker-rampage-8.png">
+				<div class="description"><h2>Double Your Fun</h2>Throwing a grenade while Gunzerking throws two grenades instead of one. The second grenade doesn't cost ammo.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/gunzerker-rampage-6.png">
+				<div class="description"><h2>5 Shots or 6</h2>Kill Skill. Killing an enemy grants a <em data-base="5"></em>% chance<span class="perLevel"> per level</span> to add an extra round of ammunition when firing instead of expending ammunition.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="4" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/gunzerker-rampage-7.png">
+				<div class="description"><h2>Yippie Ki Yay</h2>Increases the duration of Gunzerking by <em data-base="+0.6"></em> seconds<span class="perLevel"> per level</span> every time an enemy is killed while Gunzerking.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/gunzerker-rampage-9.png">
+				<div class="description"><h2>Get Some</h2>Critically Hitting an enemy decreases Gunzerking cooldown by <em data-base="-0.6"></em> seconds<span class="perLevel"> per level</span>. Has a cooldown of 4 seconds. Also passively increases crit damage by <em data-base="+3"></em>% <span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="5" data-invested="0" data-total="0">
+			<div class="skill push1" data-points="0" data-max="1"><img src="../icons/gunzerker-rampage-10.png">
+				<div class="description"><h2>Keep Firing</h2>While Gunzerking, you gain up to <em data-base="+88"></em>% Fire Rate and <em data-base="+25"></em>% Reload Speed depending on how long you hold down the trigger.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="column3 totalPoints">
+			<span class="totalPoints">0</span>
+		</div>
+		<legend>Rampage</legend>
+	</div>
+</div>
+
+<div class="treewrapper red">
+	<div class="bglayer gray"></div>
+	<div class="bglayer color"></div>
+	<div class="tree" unselectable="on">
+		<div class="tier" data-level="0" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/gunzerker-brawn-0.png">
+				<div class="description"><h2>Hard to Kill</h2><span><em data-base="+4"></em>% Maximum Health and regenerate <em data-base="+0.2"></em>% of your Maximum Health per second<span class="perLevel"> per level</span>.</span></div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/gunzerker-brawn-1.png">
+				<div class="description"><h2>Incite</h2><span>Taking damage gives <em data-base="+6"></em>% Movement Speed and <em data-base="+5"></em>% Reload Speed<span class="perLevel"> per level</span> for a few seconds.</span></div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="1" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/gunzerker-brawn-2.png">
+				<div class="description"><h2>Asbestos</h2><span><em data-base="-8"></em>% Negative Status Effect Duration<span class="perLevel"> per level</span>.</span></div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/gunzerker-brawn-3.png">
+				<div class="description"><h2>I'm the Juggernaut</h2><span>Kill Skill. Killing an enemy gives <em data-base="+12"></em>% Damage Reduction for a short time.</span></div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="2" data-invested="0" data-total="0">
+			<div class="skill push1" data-points="0" data-max="1"><img src="../icons/gunzerker-brawn-5.png">
+				<div class="description"><h2>Fistful of Hurt</h2><span>Melee Override. Throw a heavy punch dealing massive damage and knockback, as well as healing Salvador slightly. Has a cooldown of 16 seconds. This cooldown is halved while Gunzerking.</span></div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="3" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/gunzerker-brawn-4.png">
+				<div class="description"><h2>Ain't Got Time To Bleed</h2><span>While Gunzerking you regenerate up to <em data-base="+0.8"></em>% of your Maximum Health per second<span class="perLevel"> per level</span> depending on how low your health is.</span></div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/gunzerker-brawn-8.png">
+				<div class="description"><h2>Just Got Real</h2><span>Up to <em data-base="+6"></em>% Gun Damage and Melee Damage<span class="perLevel"> per level</span> depending on how low your health and shields are.</span></div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/gunzerker-brawn-6.png">
+				<div class="description"><h2>All Out of Bubblegum</h2><span><em data-base="+7"></em>% Fire Rate<span class="perLevel"> per level</span> when shield is depleted.</span></div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="4" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/gunzerker-brawn-7.png">
+				<div class="description"><h2>Bus That Can't Slow Down</h2><span><em data-base="+10"></em>% Movement Speed<span class="perLevel"> per level</span> while Gunzerking.</span></div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/gunzerker-brawn-9.png">
+				<div class="description"><h2>Sexual Tyrannosaurus</h2><span>Taking damage gives <em data-base="+0.3"></em>% Health Regeneration and <em data-base="+10"></em>% Melee Override Cooldown<span class="perLevel"> per level</span> for 5 seconds. It also reduces Gunzerking Cooldown by <em data-base="-0.1"></em> sec per hit<span class="perLevel"> per level</span>. This effect does not stack.</span></div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="5" data-invested="0" data-total="0">
+			<div class="skill push1" data-points="0" data-max="1"><img src="../icons/gunzerker-brawn-10.png">
+				<div class="description"><h2>Come At Me, Bro</h2><span>While Gunzerking, you can press [Action Skill] to taunt your enemies into attacking you. You instantly heal to Full Health and gain massive damage reduction for a few seconds. You also gain bonus Melee Damage and Melee Override Cooldown.</span></div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="column3 totalPoints">
+			<span class="totalPoints">0</span>
+		</div>
+		<legend>Brawn</legend>
+	</div>
+</div>
+</div>
+
+<div class="summary">
+	<div class="descriptionContainer"></div>
+	<div class="footer">Art &copy; 2012 <a href="http://www.gearboxsoftware.com/" target="_blank">Gearbox Studios</a>. <a href="https://www.google.com/webfonts" target="_blank">Fonts</a> by Google. Code hosted on Github. <a href="https://github.com/seigler/bl2skills.com">Source Code</a>.</div>
+	<!--#include virtual="./footer.txt"-->
+</div>
+
+</body>
+</html>
+
+<!--
+find:
+^(.+) \t[0-9]+ \t([0-9]+) \t(.+)$
+replace:
+\t\t<div class="skill" data-points="0" data-max="\2"><img src="../icons/class-tree-\i(0)">\n\t\t\t<div class="description"><h2>\1</h2>\3</div>\n\t\t\t<div class="points"></div>\n\t\t</div>
+-->

--- a/reborn/mechromancer.html
+++ b/reborn/mechromancer.html
@@ -1,0 +1,240 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>Borderlands 2 Skill Calculator: Mechromancer</title>
+	<link href='../main.css' rel='stylesheet' type='text/css'>
+	<link href='https://fonts.googleapis.com/css?family=Homenaje' rel='stylesheet' type='text/css'>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.8.1/jquery.min.js"></script>
+	<script src="skillManagerReborn.js"></script>
+</head>
+<body>
+
+<div class="header">
+	<div class="links"><a class="reset" href="reborn.html">&lt; go back</a> | <a class="reset" href="../">Home</a> | <a href="mechromancer.html" class="reset">reset</a> | <a href="#" class="permalink">Permalink to this build</a></div>
+	<h1>Borderlands<em>2</em> skill calculator <div class="stamp">(Reborn)</div></h1>
+	<h2>Gaige</h2>
+	<h3>Level <span class="charLevel">5</span> Mechromancer</h3>
+</div>
+<img unselectable="on" class="portrait" src="../mechromancerPortrait.png">
+<div class="treeCollection">
+<div class="treewrapper green">
+	<div class="bglayer gray"></div>
+	<div class="bglayer color"></div>
+	<div class="tree">
+		<div class="tier" data-level="0" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/mechromancer-bestfriendsforever-1.png">
+				<div class="description"><h2>Cooking Up Trouble</h2>While your gun's magazine is more than half full you regenerate <em data-base="0.3"></em>%<span class="perLevel"> per level</span> of maximum health per second.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/mechromancer-orderedchaos-0.png">
+				<div class="description"><h2>Smaller, Lighter, Faster</h2>Increases you reload speed <em data-base="+10"></em>%<span class="perLevel"> per level</span> but decreases your magazine size <em data-base="-2"></em>%<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="1" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/mechromancer-bestfriendsforever-2.png">
+				<div class="description"><h2>Fancy Mathematics</h2>Improves shield recharge delay (up to <em data-base="-14"></em>%<span class="perLevel"> per level</span>) and shield recharge rate (up to <em data-base="+12"></em>%<span class="perLevel"> per level</span>) based on how low your health is. The lower your health the greater the bonuses.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="1"><img src="../icons/mechromancer-bestfriendsforever-3.png">
+				<div class="description"><h2>Buck Up</h2>Deathtrap Ability. Deathtrap restores the shields of one ally to full. Additionally increases Gaige's Shield Capacity by 15%.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/mechromancer-bestfriendsforever-4.png">
+				<div class="description"><h2>The Better Half</h2>When your magazine is at least half empty you gain gun damage <em data-base="+4"></em>%<span class="perLevel"> per level</span> and fire rate <em data-base="+12"></em>%<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="2" data-invested="0" data-total="0">
+			<div class="skill push1" data-points="0" data-max="1"><img src="../icons/mechromancer-bestfriendsforever-6.png">
+				<div class="description"><h2>Upshot Robot</h2>While Deathtrap is active, if you or Deathtrap kill an enemy it increases Deathtrap's duration by 5 seconds and grants both of you a 4% stackable melee damage bonus. Bonuses are lost when Deathtrap goes away.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="3" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/mechromancer-bestfriendsforever-5.png">
+				<div class="description"><h2>Potent as a Pony</h2>Increases maximum health for you (<em data-base="+2"></em>%<span class="perLevel"> per level</span>) and Deathtrap (<em data-base="+4"></em>%<span class="perLevel"> per level</span>).</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="1"><img src="../icons/mechromancer-bestfriendsforever-8.png">
+				<div class="description"><h2>Explosive Clap</h2>Deathtrap Ability. Deathtrap causes an explosion in front of him, dealing explosive damage to all nearby enemies. Additionally increases Gaige's Melee Damage by 20%.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/mechromancer-bestfriendsforever-7.png">
+				<div class="description"><h2>Unstoppable Force</h2>Killing an enemy grants you <em data-base="+7"></em>%<span class="perLevel"> per level</span> movement speed and <em data-base="+0.8"></em>% shield regeneration<span class="perLevel"> per level</span> for a short while.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="4" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/mechromancer-bestfriendsforever-9.png">
+				<div class="description"><h2>Made of Sterner Stuff</h2>You and Deathtrap gain <em data-base="+4"></em>%<span class="perLevel"> per level</span> damage reduction against all damage types. Deathtrap gains <em data-base="+5"></em>%<span class="perLevel"> per level</span> melee damage.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/mechromancer-bestfriendsforever-10.png">
+				<div class="description"><h2>20% Cooler</h2>Increases the cooldown rate of your action skill by <em data-base="+6"></em>%<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="5" data-invested="0" data-total="0">
+			<div class="skill push1" data-points="0" data-max="1"><img src="../icons/mechromancer-bestfriendsforever-11.png">
+				<div class="description"><h2>Sharing is Caring</h2>Grants a copy of your shield to Deathtrap. Additionally increases both Gaige's Shield Capacity and Recharge Rate by 15%.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="totalPoints">
+			<span class="totalPoints">0</span>
+		</div>
+		<legend>Best Friends Forever</legend>
+	</div>
+</div>
+<div class="treewrapper blue">
+	<div class="bglayer gray"></div>
+	<div class="bglayer color"></div>
+	<div class="tree">
+		<div class="tier" data-level="0" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/mechromancer-littlebigtrouble-9.png">
+				<div class="description"><h2>Wires Talk</h2>Increases all Shock and Electrocute Damage that you inflict by <em data-base="+5"></em>%<span class="perLevel"> per level</span>, and Electrocute Chance by <em data-base="+12"></em>%<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/mechromancer-littlebigtrouble-1.png">
+				<div class="description"><h2>Myelin</h2>Grants you <em data-base="+10"></em>%<span class="perLevel"> per level</span> Resistance to Shock Damage. Also increases your Shield Capacity by <em data-base="+3"></em>%<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="1" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/mechromancer-littlebigtrouble-2.png">
+				<div class="description"><h2>Shock Storm</h2>Killing an enemy with Shock Damage causes an Electrical Storm, dealing Rank <span class="perLevel">(</span><em data-base="1"></em><span class="perLevel"> per level)</span> Shock Damage to nearby enemies. Electrical Storms are also caused by Deathtrap whenever he kills an enemy.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="1"><img src="../icons/mechromancer-littlebigtrouble-3.png">
+				<div class="description"><h2>The Stare</h2>Deathtrap Ability. Deathtrap fires a laser beam and sweeps it across the battlefield, dealing Incendiary Damage and possibly Igniting enemies.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/mechromancer-littlebigtrouble-4.png">
+				<div class="description"><h2>Strength of Five Gorillas</h2>Increases Gun Damage for you and Melee Damage for Deathtrap by <em data-base="+3"></em>%<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="2" data-invested="0" data-total="0">
+			<div class="skill push1" data-points="0" data-max="1"><img src="../icons/mechromancer-littlebigtrouble-6.png">
+				<div class="description"><h2>Shock and "AAAGGGGHHH!"</h2>Reloading your gun causes an Electrical Explosion, damaging nearby enemies. Additionally passively increases Gaige's reload speed by 10%.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="3" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/mechromancer-littlebigtrouble-5.png">
+				<div class="description"><h2>Electrical Burn</h2>When your Electrocute Status Effects deal damage to enemies, there is a <em data-base="6"></em>%<span class="perLevel"> (per level)</span> chance they will burst into flames and take Burn Damage. The amount of Burn Damage is based on the Electrocute damage dealt.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="1"><img src="../icons/mechromancer-littlebigtrouble-8.png">
+				<div class="description"><h2>One Two Boom</h2>Deathtrap Ability. Deathtrap shoots out an orb of energy at an enemy. If you shoot the orb it will explode, dealing massive Shock Damage to nearby enemies.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/mechromancer-littlebigtrouble-10.png">
+				<div class="description"><h2>Interspersed Outburst</h2>Not shooting an enemy for a short time grants you a stack of Interspersed Outburst (up to 5 stacks). The next time you shoot an enemy, all stacks of Interspersed Outburst are consumed and you deal Rank <span class="perLevel">(</span><em data-base="1"></em><span class="perLevel"> per level)</span> Slag Damage. The more stacks are consumed, the greater the chance of slagging the target.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="4" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/mechromancer-littlebigtrouble-0.png">
+				<div class="description"><h2>Hot Pepper</h2>Killing an enemy increases your Burn Damage by <em data-base="+7"></em>%<span class="perLevel"> per level</span> and Weapon Swap Speed by <em data-base="+8"></em>%<span class="perLevel"> per level</span> for a short period of time.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/mechromancer-littlebigtrouble-7.png">
+				<div class="description"><h2>Evil Enchantress</h2>Killing an enemy increases your Elemental Effect Chance by <em data-base="+10"></em>%<span class="perLevel"> per level</span> for a short period of time.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier push1" data-level="5" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="1"><img src="../icons/mechromancer-littlebigtrouble-11.png">
+				<div class="description"><h2>Make it Sparkle</h2>Shooting Deathtrap with an elemental weapon charges him with that element, causing his melee attacks to deal additional damage of that element. Additionally passively increases Gaige's Elemental Effect Chance and Damage by 15%.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="totalPoints">
+			<span class="totalPoints">0</span>
+			<span class="debug">??</span>
+		</div>
+		<legend>Little Big Trouble</legend>
+	</div>
+</div>
+<div class="treewrapper red">
+	<div class="bglayer gray"></div>
+	<div class="bglayer color"></div>
+	<div class="tree">
+		<div class="tier" data-level="0" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/mechromancer-bestfriendsforever-0.png">
+				<div class="description"><h2>Close Enough</h2>Your bullets that hit walls or other objects have a <em data-base="10"></em>% chance<span class="perLevel"> per level</span> to ricochet toward a nearby enemy dealing <em data-mod="-75" data-base="5"></em>% damage<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/mechromancer-orderedchaos-1.png">
+				<div class="description"><h2>Anarchy</h2>Killing an enemy or fully emptying your gun's magazine while in combat grants you a stack of Anarchy (up to <em data-base="20"></em> stacks<span class="perLevel"> per level</span>). For every stack of Anarchy you have, you gain +2.50% bonus gun damage, but your accuracy is decreased -2.50%. Prematurely reloading your guns removes all stacks of Anarchy. Anarchy stacks are quickly lost while in "Fight for Your Life."</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="1" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/mechromancer-orderedchaos-4.png">
+				<div class="description"><h2>Blood Soaked Shields</h2>Killing an enemy immediately restores <em data-base="20"></em>% of your shields<span class="perLevel"> per level</span>, but you lose <em data-base="2"></em>% of your current health<span class="perLevel"> per level</span>. Does not trigger without Anarchy.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="1"><img src="../icons/mechromancer-orderedchaos-3.png">
+				<div class="description"><h2>Robot Rampage</h2>Deathtrap Ability. Deathtrap lashes out with a flurry of attacks. Additionally passively increases Gaige's Melee Damage by 20%.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/mechromancer-orderedchaos-2.png">
+				<div class="description"><h2>Preshrunk Cyberpunk</h2>Increases the maximum number of Anarchy stacks you can have by <em data-base="+15"></em><span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="2" data-invested="0" data-total="0">
+			<div class="skill push1" data-points="0" data-max="1"><img src="../icons/mechromancer-orderedchaos-6.png">
+				<div class="description"><h2>Discord</h2>Prematurely reloading activates Discord granting you +65% accuracy, +25% fire rate, and 3% per second health regeneration. You constantly lose Anarchy stacks while Discord is active. Discord can be shut off by prematurely reloading again.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="3" data-invested="0" data-total="0" data-pass="1">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/mechromancer-orderedchaos-5.png">
+				<div class="description"><h2>Annoyed Android</h2>Increases the movement speed of Deathtrap by <em data-base="+7"></em>%<span class="perLevel"> per level.</span></em></div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="1"><img src="../icons/mechromancer-orderedchaos-8.png">
+				<div class="description"><h2>Rational Anarchist</h2>If you have 0 stacks of Anarchy, then the next time you would gain an Anarchy stack you instead gain 20.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/mechromancer-orderedchaos-7.png">
+				<div class="description"><h2>Typecast Iconoclast</h2>Whenever you get a stack of Anarchy there is a <em data-base="6"></em>%<span class="perLevel"> per level</span> chance you get an additional stack.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="4" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/mechromancer-orderedchaos-10.png">
+				<div class="description"><h2>The Nth Degree</h2>Every <em data-mod="10" data-base="-1"></em> <span class="perLevel"> per level</span><sup></sup> bullets that hits an enemy, one of them will ricochet toward another nearby enemy.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/mechromancer-orderedchaos-9.png">
+				<div class="description"><h2>Death From Above</h2>Shooting an enemy while in midair consumes <em data-base="1"></em> stacks of Anarchy <span class="perLevel">(1 per level)</span> and causes a Rank <span class="perLevel">(</span><em data-base="1"></em><span class="perLevel"> per level)</span> Shock-splosion, damaging nearby enemies.</div>
+				<div class="points"></div>
+			</div>	
+		</div>
+		<div class="tier push1" data-level="5" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="1"><img src="../icons/mechromancer-orderedchaos-11.png">
+				<div class="description"><h2>With Claws</h2>Melee Override Skill. While you have a stack of Anarchy, melee to digistruct claws and swipe twice at an enemy, dealing +7.5% melee Shock Damage per Anarchy stack and restoring up to 30% health. The lower your health the more health you gain. This attack consumes an Anarchy stack.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="totalPoints">
+			<span class="totalPoints">0</span>
+		</div>
+		<legend>Ordered Chaos</legend>
+	</div>
+</div>
+</div>
+
+<div class="summary">
+<div class="descriptionContainer"></div>
+	<div class="footer">Art &copy; 2012 <a href="http://www.gearboxsoftware.com/" target="_blank">Gearbox Studios</a>. <a href="https://www.google.com/webfonts" target="_blank">Fonts</a> by Google. Code hosted on Github. <a href="https://github.com/seigler/bl2skills.com">Source Code</a>.</div>
+</div>
+
+</body>
+</html>

--- a/reborn/psycho.html
+++ b/reborn/psycho.html
@@ -1,0 +1,240 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>Borderlands 2 Skill Calculator: Psycho</title>
+	<link href='../main.css' rel='stylesheet' type='text/css'>
+	<link href='https://fonts.googleapis.com/css?family=Homenaje' rel='stylesheet' type='text/css'>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.8.1/jquery.min.js"></script>
+	<script src="skillManagerReborn.js"></script>
+</head>
+<body>
+
+<div class="header">
+	<div class="links"><a class="reset" href="reborn.html">&lt; go back</a> | <a class="reset" href="../">Home</a> | <a href="psycho.html" class="reset">reset</a> | <a href="#" class="permalink">Permalink to this build</a></div>
+	<h1>Borderlands<em>2</em> skill calculator <div class="stamp">(Reborn)</div></h1>
+	<h2>Krieg</h2>
+	<h3>Level <span class="charLevel">5</span> Psycho</h3>
+</div>
+<img unselectable="on" class="portrait" src="../psychoPortrait.png">
+<div class="treeCollection">
+<div class="treewrapper green">
+	<div class="bglayer gray"></div>
+	<div class="bglayer color"></div>
+	<div class="tree">
+		<div class="tier" data-level="0" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/psycho-bloodlust-0.png">
+				<div class="description"><h2>Blood-filled Guns</h2><em data-base="+0.5"></em>% Magazine Size per Bloodlust stack<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/psycho-bloodlust-1.png">
+				<div class="description"><h2>Blood Twitch</h2><em data-base="+0.18"></em>% Weapon Swap speed per Bloodlust stack<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="1" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/psycho-bloodlust-2.png">
+				<div class="description"><h2>Taste of Blood</h2><em data-base="+0.1"></em>% damage reduction during Buzz Axe Rampage per Bloodlust stack<span class="perLevel"> per level</span>, up to a max of <em data-base="+10"></em>% damage reduction<span class="perLevel"> per level</span>. <em data-base="+10"></em> Bloodlust stacks per kill<span class="perLevel"> per level</span> during Buzz Axe Rampage.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/psycho-bloodlust-3.png">
+				<div class="description"><h2>Bloody Revival</h2><em data-base="+0.2"></em>% Gun damage during Fight For Your Life per Bloodlust stack<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/psycho-bloodlust-4.png">
+				<div class="description"><h2>Blood Overdrive</h2>Kill Skill. Killing an enemy gives <em data-base="+0.5"></em>% Melee Damage and <em data-base="-0.005"></em>s Grenade Fuse Time per Bloodlust stack<span class="perLevel"> per level</span> for a short time.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="2" data-invested="0" data-total="0">
+			<div class="skill push1" data-points="0" data-max="1"><img src="../icons/psycho-bloodlust-6.png">
+				<div class="description"><h2>Buzz Axe Bombardier</h2>When thrown, your buzz axe now has Dynamite attached to it which explodes on impact.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/psycho-bloodlust-7.png">
+				<div class="description"><h2>Fuel the Blood</h2>Kill Skill. Killing an enemy with a melee attack gives <em data-base="+0.2"></em>% Grenade Damage per Bloodlust stack<span class="perLevel"> per level</span> for a short time and adds <em data-base="+2"></em> Bloodlust stacks<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="3" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/psycho-bloodlust-9.png">
+				<div class="description"><h2>Boiling Blood</h2>Increases the time before Bloodlust stacks start to decay by <em data-base="+0.5"></em> seconds<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="1"><img src="../icons/assassin-bloodshed-4.png">
+				<div class="description"><h2>Blood Euphoria</h2>Instantly heal for 0.6% Maximum Health per Bloodlust stack when kill skills end</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/psycho-bloodlust-5.png">
+				<div class="description"><h2>Blood Bath</h2>Kill Skill. Killing an enemy with a grenade or explosion gives <em data-base="+0.5"></em>% weapon damage per Bloodlust stack<span class="perLevel"> per level</span> for a short time. Enemies killed this way have a <em data-base="15"></em>% chance<span class="perLevel"> per level</span> of dropping Grenade ammunition.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="4" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/psycho-bloodlust-8.png">
+				<div class="description"><h2>Blood Trance</h2>Increases the duration of Buzz Axe Rampage by <em data-base="+0.05"></em> seconds per Bloodlust stack (at time of activation)<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/psycho-bloodlust-10.png">
+				<div class="description"><h2>Nervous Blood</h2>Kill Skill. Killing an enemy gives <em data-base="+0.3"></em>% Reload Speed per Bloodlust stack<span class="perLevel"> per level</span> for a short time.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="5" data-invested="0" data-total="0">
+			<div class="skill push1" data-points="0" data-max="1"><img src="../icons/psycho-bloodlust-11.png">
+				<div class="description"><h2>Bloodsplosion</h2>Killing an enemy causes them to explode with an Elemental Nova matching the element of the damage that killed it
+				(Non-elemental damage will cause an explosive nova). Overkill damage is added to this damage. Each Bloodlust stacks increases this damage by 5%.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="totalPoints">
+			<span class="totalPoints">0</span>
+		</div>
+		<legend>Bloodlust</legend>
+	</div>
+</div>
+<div class="treewrapper blue">
+	<div class="bglayer gray"></div>
+	<div class="bglayer color"></div>
+	<div class="tree">
+		<div class="tier" data-level="0" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/psycho-mania-0.png">
+				<div class="description"><h2>Empty the Rage</h2><em data-base="+4"></em>% Melee Damage<span class="perLevel"> per level</span>; additional <em data-base="+10"></em>%<span class="perLevel"> per level</span> when shields or magazine is empty.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/psycho-mania-2.png">
+				<div class="description"><h2>Feed the Meat</h2><em data-base="+10"></em>% Max Health and <em data-base="+0.5"></em> sec Shield Recharge Delay<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="1" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/psycho-mania-3.png">
+				<div class="description"><h2>Embrace the Pain</h2><em data-base="+7"></em>% Fire Rate<span class="perLevel"> per level</span> when shields are down. <em data-base="+1"></em> sec Shield Recharge Delay<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="1"><img src="../icons/psycho-mania-1.png">
+				<div class="description"><h2>Pull the Pin</h2>When you die, you drop a free grenade. If you kill an enemy with it, you get double XP. Additionally increases Grenade Damage by <em data-mod="+10" data-base="0"></em>%.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/psycho-mania-4.png">
+				<div class="description"><h2>Fuel the Rampage</h2><em data-base="+20"></em>% Buzz Axe Rampage cooldown from taking damage<span class="perLevel"> per level</span>; additional <em data-base="+20"></em>%<span class="perLevel"> per level</span> from Health damage. Taking damage also gives you <em data-base="+5"></em>% movement speed<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="2" data-invested="0" data-total="0">
+			<div class="skill push1" data-points="0" data-max="1"><img src="../icons/psycho-mania-6.png">
+				<div class="description"><h2>Light the Fuse</h2>Fight For Your Life is replaced with Light the Fuse. During Light the Fuse you pull out a live bundle of dynamite and can move normally. The bundle detonates when the timer runs out. If you kill someone you are revived. Getting a revive with the bundle explosion gives you <em data-mod="+40" data-base="0"></em>% bonus Movement Speed for the remainder of the time that was left in Light the Fuse. Throw Dynamite sticks with Fire. Detonate bundle by holding Action.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="3" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/psycho-mania-7.png">
+				<div class="description"><h2>Strip the Flesh</h2><em data-base="+3"></em>% Explosive damage<span class="perLevel"> per level</span>; additional <em data-base="+3"></em>%<span class="perLevel"> per level</span> in Fight For Your Life.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="1"><img src="../icons/psycho-mania-8.png">
+				<div class="description"><h2>Redeem the Soul</h2>You can instantly Revive teammates at the cost of downing yourself. You may revive in this way only once each time Buzz axe Rampage is on cooldown. <em data-base="+50"></em>% Fight For Your Life time.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/psycho-mania-9.png">
+				<div class="description"><h2>Salt the Wound</h2>Taking damage from an enemy while your shield is down adds a stack of Salt the Wound to a maximum of 20. <em data-base="+1.5"></em>% Melee Damage and <em data-base="+1"></em>% Shotgun damage per stack<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="4" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/psycho-mania-5.png">
+				<div class="description"><h2>Thrill of the Kill</h2>Up to <em data-mod="37.5" data-base="12.5"></em>%<span class="perLevel"> per level</span> of overkill damage is returned to you as Health, depending on how low your health is. Also increases max health by <em data-base="+7"></em>%<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/psycho-mania-10.png">
+				<div class="description"><h2>Silence the Voices</h2><em data-base="+50"></em>% Melee Damage<span class="perLevel"> per level</span>. <em data-mod="12" data-base="0"></em>% chance to attack yourself with melee attacks.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="5" data-invested="0" data-total="0">
+			<div class="skill push1" data-points="0" data-max="1"><img src="../icons/psycho-mania-11.png">
+				<div class="description"><h2>Release the Beast</h2>Activating the Buzz Axe Rampage when at or below 33% of your max health remaining (i.e., when the ! is showing) instantly refills your health and transforms you into a Badass Psycho Mutant with <em data-base="+100"></em>% Melee Damage and <em data-base="+50"></em>% Damage Reduction. Buzz Axe Rampage is instantly recharged afterwards.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="totalPoints">
+			<span class="totalPoints">0</span>
+		</div>
+		<legend>Mania</legend>
+	</div>
+</div>
+<div class="treewrapper red">
+	<div class="bglayer gray"></div>
+	<div class="bglayer color"></div>
+	<div class="tree">
+		<div class="tier" data-level="0" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/psycho-hellborn-0.png">
+				<div class="description"><h2>Burn, Baby, Burn</h2><em data-base="+7"></em>% (<em data-base="+15"></em>% when on fire) burn damage<span class="perLevel"> per level</span>. <em data-base="7"></em>% chance<span class="perLevel"> per level</span> to set self on fire when igniting an enemy.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/psycho-hellborn-1.png">
+				<div class="description"><h2>Fuel the Fire</h2>Kill Skill. <em data-base="+7"></em>% chance<span class="perLevel"> per level</span> set self on fire when igniting an enemy. Killing an enemy gives <em data-base="+40"></em>% Elemental Effect Chance<span class="perLevel"> per level</span> for a short time.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="1" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/psycho-hellborn-2.png">
+				<div class="description"><h2>Numbed Nerves</h2><em data-base="+10"></em>% damage reduction<span class="perLevel"> per level</span> when on fire.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/psycho-hellborn-3.png">
+				<div class="description"><h2>Pain is Power</h2><em data-base="+5"></em>% (<em data-base="+10"></em>% when on fire) Weapon and Melee Damage<span class="perLevel"> per level</span> (except for Sniper Rifles). <em data-base="-5"></em>% Critical Hit Damage<span class="perLevel"> per level</span></div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="2" data-invested="0" data-total="0">
+			<div class="skill push1" data-points="0" data-max="1"><img src="../icons/psycho-hellborn-5.png">
+				<div class="description"><h2>Delusional Damage</h2>All Elemental Status Effects you cause have a chance to light yourself on fire. Ignite chances are determined by those accumulated from Burn, Baby, Burn and Fuel the Fire.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="3" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/psycho-hellborn-4.png">
+				<div class="description"><h2>Elemental Elation</h2>When Elemental Status Effect Damage is being done to enemies you gain stacks of Elemental Elation up to a maximum of 20. Each stack gives <em data-base="+1.0"></em>% Fire Rate and Magazine Size<span class="perLevel"> per level</span>. Stacks will not decay while you are on fire.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="1"><img src="../icons/psycho-hellborn-8.png">
+				<div class="description"><h2>Hellfire Halitosis</h2>Melee Override Skill. Pressing Melee causes you to breathe fire in a cone in front of you. Cooldown is 20 seconds.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/psycho-hellborn-6.png">
+				<div class="description"><h2>Fire Fiend</h2>Melee Attacks have a 10%<span class="perLevel"> per level</span> chance to Ignite enemies. <em data-base="+10"></em>% Weapon Accuracy and <em data-base="+7"></em>% Reload Speed when on fire.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="4" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/psycho-hellborn-9.png">
+				<div class="description"><h2>Elemental Empathy</h2>Burn status effect damage heals you for <em data-base="5"></em>% of the damage dealt<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/psycho-hellborn-7.png">
+				<div class="description"><h2>Flame Flare</h2><em data-base="+20"></em>% Burn Duration on you<span class="perLevel"> per level</span>. <em data-base="+15"></em>% chance<span class="perLevel"> per level</span> for your Burn effects to apply another Burn effect. You also gain <em data-base="+15"></em>% burn damage resistance<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="5" data-invested="0" data-total="0">
+			<div class="skill push1" data-points="0" data-max="1"><img src="../icons/psycho-hellborn-10.png">
+				<div class="description"><h2>Raving Retribution</h2>While you are on fire, taking damage from enemies will spawn homing balls of fire that seek out the attacker and explode on impact. Fireballs only trigger once per second.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="totalPoints">
+			<span class="totalPoints">0</span>
+		</div>
+		<legend>Hellborn</legend>
+	</div>
+</div>
+</div>
+
+<div class="summary">
+<div class="descriptionContainer"></div>
+	<div class="footer">Art &copy; 2012 <a href="http://www.gearboxsoftware.com/" target="_blank">Gearbox Studios</a>. <a href="https://www.google.com/webfonts" target="_blank">Fonts</a> by Google. Code hosted on Github. <a href="https://github.com/seigler/bl2skills.com">Source Code</a>.</div>
+</div>
+
+</body>
+</html>

--- a/reborn/reborn.html
+++ b/reborn/reborn.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>Borderlands 2 Skill Calculator</title>
+	<link href='../main.css' rel='stylesheet' type='text/css'>
+	<link href='http://fonts.googleapis.com/css?family=Homenaje' rel='stylesheet' type='text/css'>
+	<script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/1.8.1/jquery.min.js"></script>
+</head>
+<body class="choicePage">
+<div class="wrapper">
+<div class="header">
+	<h1>Borderlands<em>2</em> skill calculator <div class="stamp">(Reborn)</div></h1>
+	<a class="biglink" href="gunzerker.html">
+		<h2>Salvador</h2>
+		<h3>Gunzerker</h3>
+	</a>
+	<a class="biglink" href="commando.html">
+		<h2>Axton</h2>
+		<h3>Commando</h3>
+	</a>
+	<a class="biglink" href="assassin.html">
+		<h2>Zer0</h2>
+		<h3>Assassin</h3>
+	</a>
+	<a class="biglink" href="siren.html">
+		<h2>Maya</h2>
+		<h3>Siren</h3>
+	</a>
+	<a class="biglink" href="mechromancer.html">
+		<h2>Gaige</h2>
+		<h3>Mechromancer</h3>
+	</a>
+	<a class="biglink" href="psycho.html">
+		<h2>Krieg</h2>
+		<h3>Psycho</h3>
+	</a>
+</div>
+<!--#include virtual="./footer.txt"-->
+</div>
+</body>
+</html>

--- a/reborn/siren.html
+++ b/reborn/siren.html
@@ -1,0 +1,230 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>Borderlands 2 Skill Calculator: Siren</title>
+	<link href='../main.css' rel='stylesheet' type='text/css'>
+	<link href='https://fonts.googleapis.com/css?family=Homenaje' rel='stylesheet' type='text/css'>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.8.1/jquery.min.js"></script>
+	<script src="skillManagerReborn.js"></script>
+</head>
+<body>
+
+<div class="header">
+	<div class="links"><a class="reset" href="reborn.html">&lt; go back</a> | <a class="reset" href="../">Home</a> | <a href="siren.html" class="reset">reset</a> | <a href="#" class="permalink">Permalink to this build</a></div>
+	<h1>Borderlands<em>2</em> skill calculator <div class="stamp">(Reborn)</div></h1>
+	<h2>Maya</h2>
+	<h3>Level <span class="charLevel">5</span> Siren</h3>
+</div>
+<img unselectable="on" class="portrait" src="../sirenPortrait.png">
+<div class="treeCollection">
+<div class="treewrapper green">
+	<div class="bglayer gray"></div>
+	<div class="bglayer color"></div>
+	<div class="tree">
+		<div class="tier" data-level="0" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/siren-motion-0.png">
+				<div class="description"><h2>Ward</h2><em data-base="+5"></em>% Shield Capacity and <em data-base="-8"></em>% Shield Recharge Delay<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/siren-motion-1.png">
+				<div class="description"><h2>Accelerate</h2><em data-base="+4"></em>% Gun Damage and Bullet Speed<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="1" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/siren-motion-2.png">
+				<div class="description"><h2>Suspension</h2>Increases the duration of Phaselock by <em data-base="+0.5"></em>s<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/siren-motion-6.png">
+				<div class="description"><h2>Inertia</h2>Kill Skill. Killing an enemy regenerates <em data-base="+0.8"></em>% of your Shield per second and increases your Reload Speed by <em data-base="+10"></em>%<span class="perLevel"> per level</span> for a short time.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="2" data-invested="0" data-total="0">
+			<div class="skill push1" data-points="0" data-max="1"><img src="../icons/siren-motion-5.png">
+				<div class="description"><h2>Converge</h2>Your Phaselock ability now also pulls nearby enemies toward the original target. This deals a small amount of damage to the affected enemies.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="3" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/siren-motion-4.png">
+				<div class="description"><h2>Fleet</h2>Your Movement Speed increases by <em data-base="+10"></em>%<span class="perLevel"> per level</span> while your shields are depleted.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/siren-motion-8.png">
+				<div class="description"><h2>Sub-Sequence</h2>When an enemy dies under the effects of Phaselock, there is a chance for your Phaselock to seek out and affect another target (<em data-base="20"></em>% chance<span class="perLevel"> per level</span>).</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="4" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/siren-motion-7.png">
+				<div class="description"><h2>Quicken</h2>Increases the Cooldown Rate of Phaselock and your Weapon Swap Speed by <em data-base="6"></em>%<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/siren-motion-3.png">
+				<div class="description"><h2>Kinetic Reflection</h2>Kill Skill. Killing an enemy causes you to gain a <em data-base="20"></em>% chance<span class="perLevel"> per level</span> deflect bullets against nearby enemies, reducing damage to you by <em data-base="15"></em>% and dealing <em data-base="20"></em>% damage<span class="perLevel"> per level</span> for a short time.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="5" data-invested="0" data-total="0">
+			<div class="skill push1" data-points="0" data-max="1"><img src="../icons/siren-motion-9.png">
+				<div class="description"><h2>Thoughtlock</h2>Phaselock causes enemies to switch allegiance and fight amongst themselves. Additionally, Phaselock's duration is increased by 4s.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="totalPoints">
+			<span class="totalPoints">0</span>
+		</div>
+		<legend>Motion</legend>
+	</div>
+</div>
+
+<div class="treewrapper blue">
+	<div class="bglayer gray"></div>
+	<div class="bglayer color"></div>
+	<div class="tree">
+		<div class="tier" data-level="0" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/siren-harmony-0.png">
+				<div class="description"><h2>Mind's Eye</h2><em data-base="+5"></em>% Critical Hit Damage and <em data-base="+5"></em>% Accuracy<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/siren-harmony-1.png">
+				<div class="description"><h2>Sweet Release</h2>Killing an enemy who is currently Phaselocked creates <em data-base="1"></em> Life Orb<span class="perLevel"> per level</span> which automatically seeks out and heals you and your friends. The healing is stronger when you or your friend's health is low (up to 15% per Orb).</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="1" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/siren-harmony-2.png">
+				<div class="description"><h2>Restoration</h2><em data-base="+3"></em>% Maximum Health and attack allies to heal them for <em data-base="6"></em>% of the attack damage<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+			<!--Bursting Bubbles uses the Grog Nozzle drunk effect icon in-game. However, since no such icon exists yet on this website, I will use the Subsequence icon for now.-->
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/siren-motion-8.png">
+				<div class="description"><h2>Bursting Bubbles</h2>While you have an enemy Phaselocked, you and your friends gain <em data-base="+5"></em>% fire rate, reload speed, and movement speed<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="2" data-invested="0" data-total="0">
+			<div class="skill push1" data-points="0" data-max="1"><img src="../icons/siren-harmony-5.png">
+				<div class="description"><h2>Res</h2>You can instantly revive a friend in Fight for Your Life by using Phaselock on him/her. +35% Fight For your Life time</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="3" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/siren-harmony-4.png">
+				<div class="description"><h2>Elated</h2>You and your friends regenerate <em data-base="+1"></em>% health per second<span class="perLevel"> per level</span> while you have an enemy Phaselocked.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/siren-harmony-6.png">
+				<div class="description"><h2>Recompense</h2>Taking Health damage has a <em data-base="10"></em>% chance<span class="perLevel"> per level</span> of dealing an equal amount of damage to your attacker.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="4" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/siren-harmony-7.png">
+				<div class="description"><h2>Sustenance</h2>Regenerate up to <em data-base="+0.4"></em>% of your missing Health per second<span class="perLevel"> per level</span>. The lower your health the more powerful the regeneration.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/siren-harmony-8.png">
+				<div class="description"><h2>Life Tap</h2>Kill Skill. Killing an enemy gives you <em data-base="+1.2"></em>% Life Steal<span class="perLevel"> per level</span> for a short while.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="5" data-invested="0" data-total="0">
+			<div class="skill push1" data-points="0" data-max="1"><img src="../icons/siren-cataclysm-5.png">
+				<div class="description"><h2>Purple Haze</h2>Kill Skill. Killing an enemy creates a Cloud of Decay, dealing constant Slag Damage to enemies who touch it.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="totalPoints">
+			<span class="totalPoints">0</span>
+		</div>
+		<legend>Harmony</legend>
+	</div>
+</div>
+
+<div class="treewrapper red">
+	<div class="bglayer gray"></div>
+	<div class="bglayer color"></div>
+	<div class="tree">
+		<div class="tier" data-level="0" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/siren-cataclysm-1.png">
+				<div class="description"><h2>Foresight</h2>Increases Magazine Size and Reload Speed with all weapon types by <em data-base="+5"></em>% <span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/siren-cataclysm-0.png">
+				<div class="description"><h2>Flicker</h2><em data-base="+3"></em>% Incendiary Damage and Burn Damage<span class="perLevel"> per level</span>. Increases Burn Chance by <em data-base="+8"></em><span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="1" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/siren-harmony-3.png">
+				<div class="description"><h2>Heavy Hitter</h2>Adds <em data-base="+10"></em>% Gun Damage<span class="perLevel"> per level</span>, but reduces fire rate and reload speed by <em data-base="-4"></em>%<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/siren-cataclysm-2.png">
+				<div class="description"><h2>Immolate</h2>Kill Skill. Adds <em data-base="+4"></em>% Gun Damage<span class="perLevel"> per level</span> as Fire Damage to all shots fired after killing an enemy.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="2" data-invested="0" data-total="0">
+			<div class="skill push1" data-points="0" data-max="1"><img src="../icons/siren-cataclysm-3.png">
+				<div class="description"><h2>Prometheus</h2>Melee Override skill. Pressing Melee throws an Orb of Fire that constantly burns enemies near it. Cooldown is 24 seconds.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="3" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/siren-cataclysm-4.png">
+				<div class="description"><h2>Chain Reaction</h2>While you have an enemy Phaselocked all of your bullets that hit enemies have a <em data-base="8"></em>% chance<span class="perLevel"> per level</span> to ricochet and hit another nearby enemy.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="1"><img src="../icons/siren-harmony-9.png">
+				<div class="description"><h2>Void Portal</h2>Phaselocking an enemy causes a Slag Explosion, Slagging all nearby enemies.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/siren-cataclysm-6.png">
+				<div class="description"><h2>Backdraft</h2>Your melee attacks deal additional Fire Damage. Also, when your shields become depleted you create a fiery explosion, damaging nearby enemies. Your shields must fully recharge between explosions. <em data-base="1"></em> Backdraft Damage Rank<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="4" data-invested="0" data-total="0">
+			<div class="skill" data-points="0" data-max="5"><img src="../icons/siren-cataclysm-7.png">
+				<div class="description"><h2>Reaper</h2>You deal <em data-base="+8"></em>% increased Gun Damage<span class="perLevel"> per level</span> to any enemy who has more than 50% of his health remaining.</div>
+				<div class="points"></div>
+			</div>
+			<div class="skill push1" data-points="0" data-max="5"><img src="../icons/siren-cataclysm-8.png">
+				<div class="description"><h2>Blight Phoenix</h2>Kill Skill. Killing an enemy causes you to deal constant Fire and Corrosive Damage to nearby enemies and regenerate <em data-base="+0.3"></em> bullets per second for a short time. The damage is based on your Level and the Level of the Blight Phoenix. <em data-base="1"></em> Blight Phoenix Damage Rank<span class="perLevel"> per level</span>.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="tier" data-level="5" data-invested="0" data-total="0">
+			<div class="skill push1" data-points="0" data-max="1"><img src="../icons/siren-cataclysm-9.png">
+				<div class="description"><h2>Ruin</h2>Action Skill Augmentation. Phaselock now Burns, Electrocutes and Corrodes all nearby enemies.</div>
+				<div class="points"></div>
+			</div>
+		</div>
+		<div class="totalPoints">
+			<span class="totalPoints">0</span>
+		</div>
+		<legend>Cataclysm</legend>
+	</div>
+</div>
+</div>
+
+<div class="summary">
+	<div class="descriptionContainer"></div>
+	<div class="footer">Art &copy; 2012 <a href="http://www.gearboxsoftware.com/" target="_blank">Gearbox Studios</a>. <a href="https://www.google.com/webfonts" target="_blank">Fonts</a> by Google. Code hosted on Github. <a href="https://github.com/seigler/bl2skills.com">Source Code</a>.</div>
+	<!--#include virtual="./footer.txt"-->
+</div>
+
+</body>
+</html>
+
+<!--
+find:
+^(.+) \t[0-9]+ \t([0-9]+) \t(.+)$
+replace:
+\t\t<div class="skill" data-points="0" data-max="\2"><img src="../icons/class-tree-\i(0)">\n\t\t\t<div class="description"><h2>\1</h2>\3</div>\n\t\t\t<div class="points"></div>\n\t\t</div>
+-->

--- a/reborn/skillManagerReborn.js
+++ b/reborn/skillManagerReborn.js
@@ -1,0 +1,192 @@
+var mousedownbegin;
+var lastTouched;
+var touchtimer;
+var levelRequirements = [0, 5, 10, 11, 16, 21, 26];
+
+function handleMousedown(event) {
+	event.preventDefault();
+	switch (event.which) {
+		case 1: //left mouse button
+			window.clearTimeout(touchtimer);
+			mousedownbegin = (new Date()).getTime();
+			lastTouched = $(this);
+			touchtimer = window.setTimeout('checkLongTouch(true)',500);
+			break;
+//		case 2: //middle mouse button
+//			break;
+//		case 3: //right mouse button
+//			break;
+	}
+}
+function handleMouseup(event) {
+	event.preventDefault();
+	switch (event.which) {
+		case 1: //left mouse button
+			window.clearTimeout(touchtimer);
+			checkLongTouch(false);
+			break;
+		case 3: //right mouse button
+			updatePoints($(this), -1);
+			break;
+	}
+}
+
+function checkLongTouch(fromTimer) {
+	if (lastTouched !== null) {
+		if (fromTimer === true) {
+			updatePoints(lastTouched, -1);
+			updatePoints(lastTouched, -1);
+			updatePoints(lastTouched, -1);
+			updatePoints(lastTouched, -1);
+			updatePoints(lastTouched, -1);
+		} else {
+			updatePoints(lastTouched, 1);
+		}
+		lastTouched = null;
+	}
+}
+
+function updatePoints(skillHandle, change) {
+	var tree = skillHandle.parent().parent();
+	var thisLevel = parseInt(skillHandle.parent().attr("data-level"));
+	var invested = parseInt(skillHandle.parent().attr("data-invested"));
+	var tierTotal = parseInt(skillHandle.parent().attr("data-total"));
+	var treeTotal = parseInt(tree.find("span.totalPoints").text());
+	var points = parseInt(skillHandle.attr("data-points"));
+	var max = parseInt(skillHandle.attr("data-max"));
+	var charLevel = parseInt($("span.charLevel").text());
+  
+  //var canReachLevel = treeTotal >= levelRequirements[thisLevel];
+  //var canReachLevel_ = canReachLevel(treeTotal, thisLevel);
+  
+	if(change > 0) {
+		if (points < max && canReachLevel(treeTotal, thisLevel) && charLevel < 72) {
+			++points;
+		}
+	} else {
+		if (points > 0) {
+			var ok = true;
+			tree.children("div.tier").each(function(index) {
+				var level = parseInt($(this).attr("data-level"));
+				var total = parseInt($(this).attr("data-total")) - (level == thisLevel ? 1 : 0);
+				var invested = parseInt($(this).attr("data-invested")) - (level > thisLevel ? 1 : 0);
+				ok &= (
+					(level == thisLevel && total == 0 && treeTotal >= invested + total) ||
+					(level != thisLevel && total == 0) ||
+					//(total > 0 && (level * 5 <= invested))
+          (total > 0 && (canReachLevel(invested, level)))
+				);
+			});
+			if (ok) {
+				--points;
+			}
+		}
+	}
+	skillHandle.attr("data-points", points);
+	updateTree(tree);
+	updateStats();
+}
+
+function canReachLevel(treeTotal, thisLevel) {
+  //var levelRequirements = [0, 5, 10, 11, 16, 21, 26];
+  return treeTotal >= levelRequirements[thisLevel];
+}
+
+function updateTree(treeHandle) {
+	var totalPoints = 0;
+	$(treeHandle).find("div.tier").each(function(index) {
+		$(this).attr("data-invested", totalPoints); //the PREVIOUS tier running total
+		var tierLevel = parseInt($(this).attr("data-level"));
+		var tierTotal = 0;
+		$(this).children("div.skill").each(function(index) {
+			var p = parseInt($(this).attr("data-points"));
+			var m = parseInt($(this).attr("data-max"));
+			totalPoints += p;
+			tierTotal += p;
+			$(this).children("div.points").html(
+				p + "/" + m
+			);
+			//$(this).children("div.points").css("visibility", (totalPoints < levelRequirements[tierLevel]) ? "hidden" : "visible");
+      $(this).children("div.points").css("visibility", canReachLevel(totalPoints, tierLevel) ? "visible" : "hidden");
+			$(this).removeClass("partial full");
+			if (p != 0) {
+				$(this).addClass(p < m ? "partial" : "full");
+			}
+			$(this).find("em").each(function(index) {
+				var mod = parseFloat($(this).attr("data-mod"));
+				if (isNaN(mod)) mod = 0;
+				var base = parseFloat($(this).attr("data-base"));
+				var sum = Math.round((Math.max(p,1) * base + mod)*100)/100; //Math.round to eliminate goofy float errors
+				var plus = ($(this).attr("data-base").substring(0,1) === "+" ? "+" : "");
+				$(this).html((sum > 0 ? plus : (sum == 0 ? "" : "-")) + sum);
+			});
+		});
+		$(this).attr("data-total", tierTotal);
+	});
+	$(treeHandle).find("span.totalPoints").html(totalPoints);
+	//$(treeHandle).parent().children(".color").height(Math.min(80 + totalPoints * 59.0 / 5 + (totalPoints > 25 ? 21 : 0), 396));
+  //var levelRequirements = [0, 5, 10, 11, 16, 21, 26];
+  var tiersPast = 0;
+  for (var i = 1; i < 7; i++) {
+    if (canReachLevel(totalPoints, i))
+      tiersPast++;
+    else
+      break;
+  }
+  var midwayPoints = totalPoints - levelRequirements[tiersPast];
+  var displayPoints = tiersPast * 5 + midwayPoints;
+  $(treeHandle).parent().children(".color").height(Math.min(80 + displayPoints * 59.0 / 5 + (displayPoints > 25 ? 21 : 0), 396));
+  //console.clear();
+  //console.log("tiersPast: " + tiersPast);
+  //console.log("midwayPoints: " + midwayPoints);
+  //console.log("displayPoints: " + displayPoints);
+}
+
+function updateStats() {
+	var total = 0;
+	$("span.totalPoints").each(function(index) {
+		total += parseInt($(this).text());
+	});
+	$("span.charLevel").html(5+total);
+	var descriptions = "";
+	$("div.skill").each(function(index) {
+		var p = parseInt($(this).attr("data-points"));
+		if (p > 0) {
+			descriptions += "<div class='skillText'>" + $(this).children("div.description").html().replace("<h2>","<strong>").replace("</h2>", " " + p + ":</strong><div class='descriptionText'>") + "</div></div>";
+		}
+	});
+	$("div.descriptionContainer").html(descriptions);
+	var url = window.location.href.split("#")[0] + "#" + getHash();
+	$("a.permalink").attr("href",url);
+	window.location.replace(url);
+}
+
+function loadHash(hash) {
+	var h = hash.replace("#","");
+	$("div.skill").each(function(index) {
+		$(this).attr("data-points", Math.min(h.charAt(index),parseInt($(this).attr("data-max"))));
+	});
+	updateStats();
+}
+
+function getHash() {
+	var hash = "";
+	$("div.skill").each(function(index) {
+		hash += $(this).attr("data-points");
+	});
+	return hash;
+}
+
+$(document).ready(function () {
+	$('div.skill').mousedown(handleMousedown);
+	$('div.skill').mouseup(handleMouseup);
+	$("div.treewrapper").bind("contextmenu", function() { return false; });
+	if (window.location.hash != "") {
+		loadHash(window.location.hash);
+	}
+
+	$("div.tree").each(function(index) {
+		updateTree($(this));
+	});
+	updateStats();
+});


### PR DESCRIPTION
Added some support for the now-popular Reborn modpack, as I mentioned in #7. This is done in a separate folder alongside the UCP folder. HTML is edited to match the skill layout, names, and effects of all of Reborn's skills. In order to deal with the 5-5-1-5-5 skill point tiering compared to vanilla's 5x5 tiering, I had to duplicate and edit the skillManager.js file into the Reborn folder and hardcode the sequence in. I would edit the existing one to do this cleanly and dynamically, but I'm not proficient in JavaScript enough to do this yet.

Missing a skill icon for Maya's Bursting Bubbles skill, it uses the bubble icon from the Grog Nozzle drunk effect, which is not on the website. For now it uses the Subsequence icon, which may cause some confusion.